### PR TITLE
feat: add notifications and articles endpoints with type package update

### DIFF
--- a/packages/portfolio-api-types/package.json
+++ b/packages/portfolio-api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shinguakira/portfolio-api-types",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "TypeScript types for Shingu Akira Portfolio API responses",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/portfolio-api-types/src/index.ts
+++ b/packages/portfolio-api-types/src/index.ts
@@ -156,7 +156,7 @@ export type StrongPointsResponse = StrongPoint[];
 // Changelog Types
 // ============================================
 
-export type ChangeType = 'feature' | 'improvement' | 'bugfix';
+export type ChangeType = "feature" | "improvement" | "bugfix";
 
 export type ChangelogItem = {
   version: string;
@@ -196,3 +196,46 @@ export type Links = {
 
 /** Response from GET /api/links */
 export type LinksResponse = Links;
+
+// ============================================
+// Notification Types
+// ============================================
+
+export type Notification = {
+  title: string;
+  content: string;
+  date: string;
+};
+
+/** Response from GET /api/notifications?lang=ja|en */
+export type NotificationsResponse = Notification[];
+
+// ============================================
+// Article Types
+// ============================================
+
+export type ArticleTag = {
+  name: string;
+  versions: string[];
+};
+
+export type Article = {
+  id: string;
+  title: string;
+  url: string;
+  created_at: string;
+  updated_at: string;
+  likes_count: number;
+  comments_count: number;
+  stocks_count: number;
+  reactions_count: number;
+  tags: ArticleTag[];
+};
+
+export type ArticlesData = {
+  totalCount: number;
+  articles: Article[];
+};
+
+/** Response from GET /api/articles */
+export type ArticlesResponse = ArticlesData;

--- a/ts/src/constants/index.ts
+++ b/ts/src/constants/index.ts
@@ -9,3 +9,4 @@ export * from './skill.js';
 export * from './strongPoint.js';
 export * from './workExperience.js';
 export * from './links.js';
+export * from './notification.js';

--- a/ts/src/constants/notification.ts
+++ b/ts/src/constants/notification.ts
@@ -1,0 +1,28 @@
+import {MultilingualNotification} from '../types/notification.js';
+
+export const notifications: MultilingualNotification[] = [
+  {
+    date: '2026-03-12',
+    ja: {
+      title: 'IT業界に興味がある方を募集しています',
+      content:
+        'IT業界に就職したい人、ITを学びたい人、フリーランスになりたい人を募集しています。お気軽にご連絡ください。',
+    },
+    en: {
+      title: 'Looking for People Interested in the IT Industry',
+      content:
+        'Looking for people who want to work in the IT industry, learn IT, or become freelancers. Feel free to contact me.',
+    },
+  },
+  {
+    date: '2026-03-12',
+    ja: {
+      title: 'フリーランスになりました',
+      content: '2025年7月からフリーランスとして活動を開始しました。',
+    },
+    en: {
+      title: 'Became a Freelancer',
+      content: 'I started working as a freelancer from July 2025.',
+    },
+  },
+];

--- a/ts/src/controllers/portfolio.ts
+++ b/ts/src/controllers/portfolio.ts
@@ -12,6 +12,8 @@ import type {
   StrongPointsResponse,
   ContactResponse,
   LinksResponse,
+  NotificationsResponse,
+  ArticlesResponse,
   WorkExperience,
   Project,
 } from '@shinguakira/portfolio-api-types';
@@ -29,6 +31,7 @@ import {
   links,
   strongPoint,
   otherSkills,
+  notifications,
 } from '../constants/index.js';
 import {generatePortfolioPDF} from '../services/pdfService.js';
 
@@ -262,6 +265,68 @@ export const getStrongPoints = (
     res
       .status(500)
       .json({message: 'Error fetching strong points data', data: null});
+  }
+};
+
+export const getNotifications = (
+  req: Request,
+  res: ExpressResponse<ApiResponse<NotificationsResponse>>
+) => {
+  try {
+    const lang = req.query.lang as string;
+    const localizedNotifications = notifications.map((item) => ({
+      date: item.date,
+      ...(lang === 'en' ? item.en : item.ja),
+    }));
+    res.status(200).json({
+      message: 'Notifications data fetched successfully',
+      data: localizedNotifications,
+    });
+  } catch (error) {
+    res
+      .status(500)
+      .json({message: 'Error fetching notifications data', data: null});
+  }
+};
+
+const QIITA_USER_ID = 'ShinguAkira';
+
+export const getArticles = async (
+  req: Request,
+  res: ExpressResponse<ApiResponse<ArticlesResponse>>
+) => {
+  try {
+    const response = await fetch(
+      `https://qiita.com/api/v2/users/${QIITA_USER_ID}/items?page=1&per_page=100`
+    );
+    if (!response.ok) {
+      res
+        .status(500)
+        .json({message: 'Error fetching articles from Qiita', data: null});
+      return;
+    }
+    const articles = await response.json();
+    const mappedArticles = articles.map(
+      (article: Record<string, unknown>) => ({
+        id: article.id,
+        title: article.title,
+        url: article.url,
+        created_at: article.created_at,
+        updated_at: article.updated_at,
+        likes_count: article.likes_count,
+        comments_count: article.comments_count,
+        stocks_count: article.stocks_count,
+        reactions_count: article.reactions_count,
+        tags: article.tags,
+      })
+    );
+    const data: ArticlesResponse = {
+      totalCount: mappedArticles.length,
+      articles: mappedArticles,
+    };
+    res.status(200).json({message: 'Articles data fetched successfully', data});
+  } catch (error) {
+    res.status(500).json({message: 'Error fetching articles data', data: null});
   }
 };
 

--- a/ts/src/routes/portfolio.ts
+++ b/ts/src/routes/portfolio.ts
@@ -12,6 +12,8 @@ import {
   getLinks,
   getStrongPoints,
   getOtherSkills,
+  getNotifications,
+  getArticles,
   downloadPortfolioPDF,
 } from '../controllers/portfolio.js';
 
@@ -30,6 +32,8 @@ router.get('/faqs', getFaqs);
 router.get('/links', getLinks);
 router.get('/strong-points', getStrongPoints);
 router.get('/other-skills', getOtherSkills);
+router.get('/notifications', getNotifications);
+router.get('/articles', getArticles);
 router.get('/download-pdf', downloadPortfolioPDF);
 
 export {router};

--- a/ts/src/tests/articles.test.ts
+++ b/ts/src/tests/articles.test.ts
@@ -1,0 +1,63 @@
+import {describe, it, expect} from 'vitest';
+import request from 'supertest';
+import app from '../index.js';
+
+describe('GET /api/articles', () => {
+  it('should respond with a 200 status code and articles data with totalCount', async () => {
+    const response = await request(app).get('/api/articles');
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe('Articles data fetched successfully');
+    expect(response.body.data).toHaveProperty('totalCount');
+    expect(typeof response.body.data.totalCount).toBe('number');
+    expect(response.body.data.totalCount).toBeGreaterThan(0);
+    expect(Array.isArray(response.body.data.articles)).toBe(true);
+    expect(response.body.data.articles.length).toBe(
+      response.body.data.totalCount
+    );
+  });
+
+  it('should contain the oldest 3 known articles with correct titles', async () => {
+    const response = await request(app).get('/api/articles');
+    const articles = response.body.data.articles;
+
+    const oldestArticles = [
+      {
+        id: '1d78bb49c98f6f092e8f',
+        title: '資格取得履歴と各資格評価',
+      },
+      {
+        id: 'bf2118670191ba8a3cb3',
+        title: 'REACT DEVELOPER CERTIFIED LEVEL 1 取得しました',
+      },
+      {
+        id: 'ec241ac26f7c086a90bf',
+        title: 'ReactとSeleniumの相性が悪い気がするという話',
+      },
+    ];
+
+    for (const expected of oldestArticles) {
+      const found = articles.find(
+        (a: {id: string}) => a.id === expected.id
+      );
+      expect(found).toBeDefined();
+      expect(found.title).toBe(expected.title);
+    }
+  });
+
+  it('should have correct fields for each article', async () => {
+    const response = await request(app).get('/api/articles');
+    const article = response.body.data.articles[0];
+
+    expect(article).toHaveProperty('id');
+    expect(article).toHaveProperty('title');
+    expect(article).toHaveProperty('url');
+    expect(article).toHaveProperty('created_at');
+    expect(article).toHaveProperty('updated_at');
+    expect(article).toHaveProperty('likes_count');
+    expect(article).toHaveProperty('comments_count');
+    expect(article).toHaveProperty('stocks_count');
+    expect(article).toHaveProperty('reactions_count');
+    expect(article).toHaveProperty('tags');
+    expect(Array.isArray(article.tags)).toBe(true);
+  });
+});

--- a/ts/src/tests/notifications.test.ts
+++ b/ts/src/tests/notifications.test.ts
@@ -1,0 +1,27 @@
+import {describe, it, expect} from 'vitest';
+import request from 'supertest';
+import app from '../index.js';
+import {
+  notifications_ja,
+  notifications_en,
+} from './testData/expected-json/notifications.js';
+
+describe('GET /api/notifications', () => {
+  it('should respond with a 200 status code and the Japanese notifications data by default', async () => {
+    const response = await request(app).get('/api/notifications');
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe(
+      'Notifications data fetched successfully'
+    );
+    expect(response.body.data).toEqual(notifications_ja);
+  });
+
+  it('should respond with a 200 status code and the English notifications data when lang=en', async () => {
+    const response = await request(app).get('/api/notifications?lang=en');
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe(
+      'Notifications data fetched successfully'
+    );
+    expect(response.body.data).toEqual(notifications_en);
+  });
+});

--- a/ts/src/tests/testData/expected-json/notifications.ts
+++ b/ts/src/tests/testData/expected-json/notifications.ts
@@ -1,0 +1,27 @@
+export const notifications_ja = [
+  {
+    date: '2026-03-12',
+    title: 'IT業界に興味がある方を募集しています',
+    content:
+      'IT業界に就職したい人、ITを学びたい人、フリーランスになりたい人を募集しています。お気軽にご連絡ください。',
+  },
+  {
+    date: '2026-03-12',
+    title: 'フリーランスになりました',
+    content: '2025年7月からフリーランスとして活動を開始しました。',
+  },
+];
+
+export const notifications_en = [
+  {
+    date: '2026-03-12',
+    title: 'Looking for People Interested in the IT Industry',
+    content:
+      'Looking for people who want to work in the IT industry, learn IT, or become freelancers. Feel free to contact me.',
+  },
+  {
+    date: '2026-03-12',
+    title: 'Became a Freelancer',
+    content: 'I started working as a freelancer from July 2025.',
+  },
+];

--- a/ts/src/types/article.tsx
+++ b/ts/src/types/article.tsx
@@ -3,11 +3,10 @@ export type ArticleProps = {
   title: string;
   url: string;
   created_at: string;
-  // ... add more fields if needed
-};
-
-type QiitaArticle = ArticleProps & {
-  //   likes_count: number;
-  //   tags: string[];
-  // add more fields for Qiita specific fields
+  updated_at: string;
+  likes_count: number;
+  comments_count: number;
+  stocks_count: number;
+  reactions_count: number;
+  tags: {name: string; versions: string[]}[];
 };

--- a/ts/src/types/index.ts
+++ b/ts/src/types/index.ts
@@ -12,3 +12,4 @@ export * from './downloadLink.js';
 export * from './strongPoint.js';
 export * from './links.js';
 export * from './pdfTypes.js';
+export * from './notification.js';

--- a/ts/src/types/notification.ts
+++ b/ts/src/types/notification.ts
@@ -1,0 +1,10 @@
+export type MultilingualNotificationContent = {
+  title: string;
+  content: string;
+};
+
+export type MultilingualNotification = {
+  date: string;
+  ja: MultilingualNotificationContent;
+  en: MultilingualNotificationContent;
+};


### PR DESCRIPTION
Add bilingual notification endpoint (GET /api/notifications) with static data and articles endpoint (GET /api/articles) fetching from Qiita API with totalCount. Bump @shinguakira/portfolio-api-types to v1.2.0.